### PR TITLE
Force discards local changes

### DIFF
--- a/tasks/speckleadmin-install.yml
+++ b/tasks/speckleadmin-install.yml
@@ -18,6 +18,7 @@
   git:
     repo: "https://github.com/speckleworks/SpeckleAdmin.git"
     dest: "/home/speckle/speckleserver/plugins/SpeckleAdmin/"
+    force: true
   become: yes
   become_user: speckle
   when:


### PR DESCRIPTION
There is a feature in Speckle Admin where the dist folder has been checked in. Using force here runs a git reset --hard HEAD before pulling the new code from GitHub

See chat in Slack for details of the issues this causes https://arupconsulting.slack.com/archives/C013VEE6WA1/p1594219519038100