### PR TITLE
[SPEC-111] use the arup-group speckle admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported Operating Systems
 Role Variables
 --------------
 
-`speckleserver_admin`: Install the SpeckleServer Admin interface from [SpeckleWorks SpeckleAdmin git](http://github.com/speckleworks/SpeckleAdmin). Boolean value, default is false.
+`speckleserver_admin`: Install the SpeckleServer Admin interface from [Arup SpeckleAdmin git](http://github.com/arup-group/SpeckleAdmin). Boolean value, default is false.
 
 `speckleserver_version`: Version of SpeckleServer to download and install. Can be a numbered version in major.minor.micro format or "latest" (default: `latest`)
 

--- a/tasks/speckleadmin-install.yml
+++ b/tasks/speckleadmin-install.yml
@@ -33,7 +33,7 @@
 - name: "Get release info for Speckleserver from github"
   uri:
     url: |
-      https://api.github.com/repos/speckleworks/SpeckleAdmin/releases/{{ speckleadmin_api_stem }}
+      https://api.github.com/repos/arup-group/SpeckleAdmin/releases/{{ speckleadmin_api_stem }}
     return_content: true
   register: speckleadmin_ghub
   until: speckleadmin_ghub.json.tarball_url is defined


### PR DESCRIPTION
Use the forked version of speckle admin rather than the speckleworks version